### PR TITLE
Update git_remote.rb

### DIFF
--- a/app/models/repository/git_remote.rb
+++ b/app/models/repository/git_remote.rb
@@ -99,7 +99,7 @@ class Repository::GitRemote < Repository::Git
       return "#{clone_url} is not a valid remote."
     end
 
-    if Dir.exists? clone_path
+    if Dir.exist? clone_path
       existing_repo_remote, status = RedmineGitRemote::PoorMansCapture3::capture2("git", "--git-dir", clone_path, "config", "--get", "remote.origin.url")
       return "Unable to run: git --git-dir #{clone_path} config --get remote.origin.url" unless status.success?
 


### PR DESCRIPTION
Change exists to exist for new ruby version

When using this fork, I found that I couldn't create a new repository without this change. 

Source for "exists" changing to "exist"
https://github.com/oneclick/rubyinstaller2/issues/331